### PR TITLE
Enhance HA secrets sync to remove unreferenced DB secrets

### DIFF
--- a/hassio-1password-addon/CHANGELOG.md
+++ b/hassio-1password-addon/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Updated web dependencies and lockfile (including next-intl, vite, vitest, and form-data)
 - Updated web package manager configuration to pnpm 11.9.0 and removed deprecated .npmrc
 - Fixed Next.js dev/prod asset path handling in web config (assetPrefix and image path)
+- Updated HA secrets sync to drop DB secrets that are no longer referenced in any YAML files (including `secrets.yaml`)
+- Removed stale/unneeded HA secrets from the web UI list after sync by deleting unreferenced records from the DB
 
 ## 0.2.1
 

--- a/hassio-1password-addon/web/src/service/secret.service.ts
+++ b/hassio-1password-addon/web/src/service/secret.service.ts
@@ -22,7 +22,10 @@ export class HASecretService {
    * Sync secrets from the secret helper to the database
    */
   async syncSecrets() {
-    const secrets = await this.secretHelper.scanForSecrets();
+    const [secrets, existingSecrets] = await Promise.all([
+      this.secretHelper.scanForSecrets(),
+      this.db.secret.findMany({ select: { id: true } })
+    ]);
 
     await Promise.all(
       secrets.map(async (secret) => {
@@ -33,6 +36,21 @@ export class HASecretService {
         });
       })
     );
+
+    const referencedSecretIds = new Set(secrets);
+    const staleSecretIds = existingSecrets
+      .map((secret) => secret.id)
+      .filter((id) => !referencedSecretIds.has(id));
+
+    if (staleSecretIds.length > 0) {
+      await this.db.secret.deleteMany({
+        where: {
+          id: {
+            in: staleSecretIds
+          }
+        }
+      });
+    }
   }
 
   /**

--- a/hassio-1password-addon/web/test/service/secret.service.test.ts
+++ b/hassio-1password-addon/web/test/service/secret.service.test.ts
@@ -34,7 +34,8 @@ function createMockDb() {
       findUnique: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
-      upsert: vi.fn()
+      upsert: vi.fn(),
+      deleteMany: vi.fn()
     }
   } as any;
 }
@@ -60,6 +61,7 @@ describe('HASecretService', () => {
         'db_password',
         'api_key'
       ]);
+      mockDb.secret.findMany.mockResolvedValue([]);
       mockDb.secret.upsert.mockResolvedValue({});
 
       await service.syncSecrets();
@@ -75,10 +77,54 @@ describe('HASecretService', () => {
 
     it('does nothing when there are no secrets to sync', async () => {
       vi.mocked(mockSecretHelper.scanForSecrets).mockResolvedValue([]);
+      mockDb.secret.findMany.mockResolvedValue([]);
 
       await service.syncSecrets();
 
       expect(mockDb.secret.upsert).not.toHaveBeenCalled();
+      expect(mockDb.secret.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('deletes secrets that are no longer referenced in YAML files', async () => {
+      vi.mocked(mockSecretHelper.scanForSecrets).mockResolvedValue([
+        'db_password'
+      ]);
+      mockDb.secret.findMany.mockResolvedValue([
+        { id: 'db_password' },
+        { id: 'old_api_key' }
+      ]);
+      mockDb.secret.upsert.mockResolvedValue({});
+      mockDb.secret.deleteMany.mockResolvedValue({ count: 1 });
+
+      await service.syncSecrets();
+
+      expect(mockDb.secret.deleteMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['old_api_key']
+          }
+        }
+      });
+    });
+
+    it('deletes all db secrets when no references are found anywhere', async () => {
+      vi.mocked(mockSecretHelper.scanForSecrets).mockResolvedValue([]);
+      mockDb.secret.findMany.mockResolvedValue([
+        { id: 'stale_1' },
+        { id: 'stale_2' }
+      ]);
+      mockDb.secret.deleteMany.mockResolvedValue({ count: 2 });
+
+      await service.syncSecrets();
+
+      expect(mockDb.secret.upsert).not.toHaveBeenCalled();
+      expect(mockDb.secret.deleteMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['stale_1', 'stale_2']
+          }
+        }
+      });
     });
   });
 


### PR DESCRIPTION
- If a secret is no longer referenced in any of the YAML files - it'll be dropped with the next "sync"

Fixes #812 